### PR TITLE
Compatibility with Magento >=2.4.7-beta3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "magento/module-config": "^101.0.0|^101.1.0",
     "magento/module-page-cache": "^100.0",
     "rosell-dk/webp-convert": "^2.0",
-    "psr/log": "^1.0",
+    "psr/log": "^1 || ^2 || ^3",
     "php": ">=7.1.0",
     "ext-json": "*",
     "ext-pcre": "*",


### PR DESCRIPTION
Magento Framework requires (not explicitly) psr/log >= 2.0, current requirement can block update of the magento core function which will cause critical error.